### PR TITLE
Changement de la condition (obsolète avec jQuery 1.9) pour détecter IE

### DIFF
--- a/zoombox.js
+++ b/zoombox.js
@@ -85,7 +85,8 @@ $.fn.zoombox = function(opts){
      */
     return this.each(function(){
         // No zoombox for IE6
-        if($.browser.msie && $.browser.version < 7 && !window.XMLHttpRequest){
+        if(( !navigator.userAgent.match(/mozilla/i) && 
+        ! navigator.userAgent.match(/webkit/i) ) && $.browser.version < 7 && !window.XMLHttpRequest){
             return false;
         }
         var obj = this;


### PR DESCRIPTION
Salut ! 
Lorsque j'ai voulu installer Zoombox pour mon site il s'est avéré que la détection d'IE que tu avais écrite n'était plus compatible avec jQuery 1.9. J'ai donc fait mes petites recherches pour trouver une manière de contourner le problème. 
Je ne sais pas si c'est une bonne méthode mais pour moi c'est correct :).
