### PR TITLE
Does not add images with zskip class to the gallery

### DIFF
--- a/zoombox.js
+++ b/zoombox.js
@@ -90,22 +90,32 @@ $.fn.zoombox = function(opts){
         }
         var obj = this;
         var galleryRegExp =  /zgallery([0-9]+)/;
+        var skipRegExp =  /zskip/;
         var gallery = galleryRegExp.exec($(this).attr("class"));
+        var skip = skipRegExp.exec($(this).attr("class"));
         var tmpimageset = false;
         if(gallery != null){
             if(!images[gallery[1]]){
                 images[gallery[1]]=new Array();
             }
-            images[gallery[1]].push($(this));
+            if (skip == null) {
+                images[gallery[1]].push($(this));
+            }
             var pos = images[gallery[1]].length-1;
             tmpimageset = images[gallery[1]];
         }
         $(this).unbind('click').click(function(){
             options = $.extend({},$.zoombox.options,opts);
             if(state!='closed') return false;
-            elem = $(obj);
-            link = elem.attr('href');
+            if (skip != null) {
+                if (pos < images[gallery[1]].length-1) {
+                    elem = images[gallery[1]][pos+1];
+                }
+            } else {   
+                elem = $(obj);
+            }
             imageset = tmpimageset;
+            link = elem.attr('href');
             position = pos;
             load();
             return false;


### PR DESCRIPTION
- Use case: the gallery has to show up by clicking on any image but the same image is on the page multiple times.
- Current behavior: the same image appears in the gallery multiple times.
- Desired behavior: all images appear only once.

By adding class="zskip" to an image, clicking on it will make the gallery show up but this image won't be in the gallery.
