### PR TITLE
Correction bug du a jquery 1.9

### DIFF
--- a/zoombox.js
+++ b/zoombox.js
@@ -85,9 +85,10 @@ $.fn.zoombox = function(opts){
      */
     return this.each(function(){
         // No zoombox for IE6
+        /*
         if($.browser.msie && $.browser.version < 7 && !window.XMLHttpRequest){
             return false;
-        }
+        }*/
         var obj = this;
         var galleryRegExp =  /zgallery([0-9]+)/;
         var gallery = galleryRegExp.exec($(this).attr("class"));


### PR DESCRIPTION
Les versions jquery évoluent et ne se ressemble pas.
Depuis la version 1.9, certaines fonctions ont disparu: http://jquery.com/upgrade-guide/1.9/#jquery-migrate-plugin et notament $.browser. Ce push est une proposition intermédiaire qui supprimer les quelques lignes liés à ie6.
Question, doit-on toujours rendre un site et un plugin compatible avec un navigateur complètement dépassé, si vous, la solution sera d'étendre le plugin à un autre plugin comment http://modernizr.com/.
Bonne journée. 
