### PR TITLE
Mise à jour du CSS pour fonctionner avec les modales de boostrap

### DIFF
--- a/zoombox.css
+++ b/zoombox.css
@@ -6,14 +6,14 @@
 	background-color:#000;
 	position:fixed;
 	width:100%;
-	z-index:90;
+	z-index:1051;
 	height:100%;
 	top:0;
 	left:0;
 }
 #zoombox .zoombox_container{
 	position:absolute;
-	z-index:100;
+	z-index:1052;
 }
 #zoombox .relative{
 	position:relative;
@@ -65,7 +65,7 @@
 }
 #zoombox .zoombox_gallery{
 	position:fixed;
-	z-index:120;
+	z-index:1054;
 	bottom:-60px;
 	left:0;
 	right:0;
@@ -107,7 +107,7 @@
 	top:50%;
 	left:50%;
 	margin:-20px 0 0 -20px;
-	z-index:110;
+	z-index:1053;
 }
 /** Zoombox Theme **/
 .zoombox .zoombox_container{


### PR DESCRIPTION
Salut, tout d'abord bravo et merci pour ton module, vraiment très pratique !

J'ai voulu l'utiliser dans des modales du Twitter bootstrap, sauf que le Z-Index de ces dernière était plus haut que le tiens ! Du coup la Zoombox se trouvais derrière
En changeant le Z-index de tout le fichier CSS à une valeur supérieure à 1050 (Twitter Bootstrap Modal Z-index) les modales fonctionnent correctement en se positionnant sous la zoombox dans le cas où le lien se trouve dans une modale !

En espérant que tu merge,
Cordialement

PS : si tu ne l'avais pas fait avant volontairement, explique moi pourquoi :)
