### PR TITLE
Compatibilité jQuery 3

### DIFF
--- a/zoombox.js
+++ b/zoombox.js
@@ -203,7 +203,7 @@ function gallery(){
             if(i==position){ img.addClass('current'); }
 
             // Listen the loading of Images
-            $("<img/>").data('img',img).attr("src", imgSrc).load(function() {
+            $("<img/>").data('img',img).attr("src", imgSrc).on('load', function() {
                     loaded++;
                     var img = $(this).data('img');
                     img.width(Math.round(img.height() * this.width/this.height));


### PR DESCRIPTION
Une autre personne a déjà fait une PR pour régler ce soucis (et d'autres), mais elle n'a jamais été Merge donc je règle juste ce bug qui oblige l'utilisateur de rafraichir la page si il veut quitter la photo et n'affiche pas le bandeau avec toutes les images.